### PR TITLE
Fix problem with LocalDateTimeArgument and LocalDateTimeMapper

### DIFF
--- a/dropwizard-java8-jdbi/pom.xml
+++ b/dropwizard-java8-jdbi/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <prerequisites>
@@ -22,6 +23,12 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-jdbi</artifactId>
             <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/LocalDateTimeArgument.java
+++ b/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/LocalDateTimeArgument.java
@@ -8,7 +8,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 
 /**
  * An {@link Argument} for {@link LocalDateTime} objects.
@@ -26,7 +25,7 @@ public class LocalDateTimeArgument implements Argument {
                       final PreparedStatement statement,
                       final StatementContext ctx) throws SQLException {
         if (value != null) {
-            statement.setTimestamp(position, new Timestamp(value.toEpochSecond(ZoneOffset.UTC)));
+            statement.setTimestamp(position, Timestamp.valueOf(value));
         } else {
             statement.setNull(position, Types.TIMESTAMP);
         }

--- a/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/LocalDateTimeMapper.java
+++ b/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/LocalDateTimeMapper.java
@@ -6,7 +6,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 
 /**
  * A {@link TypedMapper} to map {@link LocalDateTime} objects.
@@ -19,7 +18,7 @@ public class LocalDateTimeMapper extends TypedMapper<LocalDateTime> {
         if (timestamp == null) {
             return null;
         }
-        return LocalDateTime.ofEpochSecond(timestamp.getTime(), 0, ZoneOffset.UTC);
+        return timestamp.toLocalDateTime();
     }
 
     @Override
@@ -28,6 +27,6 @@ public class LocalDateTimeMapper extends TypedMapper<LocalDateTime> {
         if (timestamp == null) {
             return null;
         }
-        return LocalDateTime.ofEpochSecond(timestamp.getTime(), 0, ZoneOffset.UTC);
+        return timestamp.toLocalDateTime();
     }
 }

--- a/dropwizard-java8-jdbi/src/test/java/io/dropwizard/java8/jdbi/args/LocalDateTimeArgumentTest.java
+++ b/dropwizard-java8-jdbi/src/test/java/io/dropwizard/java8/jdbi/args/LocalDateTimeArgumentTest.java
@@ -1,0 +1,32 @@
+package io.dropwizard.java8.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.StatementContext;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDateTime;
+
+public class LocalDateTimeArgumentTest {
+
+    private final PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+    private final StatementContext context = Mockito.mock(StatementContext.class);
+
+    @Test
+    public void apply() throws Exception {
+        LocalDateTime localDateTime = LocalDateTime.parse("2007-12-03T10:15:30.375");
+
+        new LocalDateTimeArgument(localDateTime).apply(1, statement, context);
+
+        Mockito.verify(statement).setTimestamp(1, Timestamp.valueOf("2007-12-03 10:15:30.375"));
+    }
+
+    @Test
+    public void apply_ValueIsNull() throws Exception {
+        new LocalDateTimeArgument(null).apply(1, statement, context);
+
+        Mockito.verify(statement).setNull(1, Types.TIMESTAMP);
+    }
+}

--- a/dropwizard-java8-jdbi/src/test/java/io/dropwizard/java8/jdbi/args/LocalDateTimeMapperTest.java
+++ b/dropwizard-java8-jdbi/src/test/java/io/dropwizard/java8/jdbi/args/LocalDateTimeMapperTest.java
@@ -1,0 +1,52 @@
+package io.dropwizard.java8.jdbi.args;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class LocalDateTimeMapperTest {
+
+    private final ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+    @Test
+    public void extractByName() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        LocalDateTime actual = new LocalDateTimeMapper().extractByName(resultSet, "name");
+
+        assertThat(actual).isEqualTo(LocalDateTime.parse("2007-12-03T10:15:30.375"));
+    }
+
+    @Test
+    public void extractByName_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp("name")).thenReturn(null);
+
+        LocalDateTime actual = new LocalDateTimeMapper().extractByName(resultSet, "name");
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    public void extractByIndex() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(Timestamp.valueOf("2007-12-03 10:15:30.375"));
+
+        LocalDateTime actual = new LocalDateTimeMapper().extractByIndex(resultSet, 1);
+
+        assertThat(actual).isEqualTo(LocalDateTime.parse("2007-12-03T10:15:30.375"));
+    }
+
+    @Test
+    public void extractByIndex_TimestampIsNull() throws Exception {
+        when(resultSet.getTimestamp(1)).thenReturn(null);
+
+        LocalDateTime actual = new LocalDateTimeMapper().extractByIndex(resultSet, 1);
+
+        assertThat(actual).isNull();
+    }
+}


### PR DESCRIPTION
LocalDateTimeArgument would persist a timestamp that was incorrect. It only took the seconds and would loose the millisecond information.