### PR TITLE
Add a testing helper class (in a seprate module) to simplify module use

### DIFF
--- a/dropwizard-java8-testing/pom.xml
+++ b/dropwizard-java8-testing/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <prerequisites>
+        <maven>3.0.0</maven>
+    </prerequisites>
+
+    <parent>
+        <groupId>io.dropwizard.modules</groupId>
+        <artifactId>dropwizard-java8-parent</artifactId>
+        <version>0.8.0-3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>dropwizard-java8-testing</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Dropwizard testing with Java 8 support</name>
+    <description>Testing helper for Dropwizard with Java 8 features</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.modules</groupId>
+            <artifactId>dropwizard-java8</artifactId>
+            <version>0.8.0-3-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/dropwizard-java8-testing/src/main/java/io/dropwizard/java8/testing/junit/ResourceTestRuleBuilder.java
+++ b/dropwizard-java8-testing/src/main/java/io/dropwizard/java8/testing/junit/ResourceTestRuleBuilder.java
@@ -1,0 +1,15 @@
+package io.dropwizard.java8.testing.junit;
+
+import io.dropwizard.java8.jersey.OptionalMessageBodyWriter;
+import io.dropwizard.java8.jersey.OptionalParamFeature;
+import io.dropwizard.testing.junit.ResourceTestRule;
+
+public class ResourceTestRuleBuilder {
+
+    public static ResourceTestRule.Builder builder() {
+        return new ResourceTestRule.Builder()
+                .addProvider(OptionalMessageBodyWriter.class)
+                .addProvider(OptionalParamFeature.class);
+    }
+
+}

--- a/dropwizard-java8-testing/src/test/java/io/dropwizard/java8/testing/junit/ResourceTestRuleBuilderTest.java
+++ b/dropwizard-java8-testing/src/test/java/io/dropwizard/java8/testing/junit/ResourceTestRuleBuilderTest.java
@@ -1,0 +1,78 @@
+package io.dropwizard.java8.testing.junit;
+
+import io.dropwizard.java8.testing.junit.TestResource.Check;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.ws.rs.client.ClientResponseContext;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+public class ResourceTestRuleBuilderTest {
+
+    Check check = mock(Check.class);
+
+    @Rule
+    public ResourceTestRule testRule = ResourceTestRuleBuilder.builder().addResource(new TestResource(check)).build();
+
+    @Test
+    public void testOptionalParamsNotPresent() {
+        String result = testRule.client()
+                .target("/optional/params")
+                .request()
+                .get(String.class);
+
+        verify(check, times(1)).check(empty(), empty());
+        assertEquals("{}", result);
+    }
+
+    @Test
+    public void testOptionalParamsPresent() {
+        String result = testRule.client()
+                .target("/optional/params")
+                .queryParam("p1", "One")
+                .queryParam("p2", 2)
+                .request()
+                .get(String.class);
+
+        verify(check, times(1)).check(of("One"), of(2l));
+        assertEquals("{}", result);
+    }
+
+    @Test
+    public void testOptionalSingleParamPresent() {
+        String result = testRule.client()
+                .target("/optional/params")
+                .queryParam("p2", 2)
+                .request()
+                .get(String.class);
+
+        verify(check, times(1)).check(empty(), of(2l));
+        assertEquals("{}", result);
+    }
+
+    @Test
+    public void testOptionalResponseSome() {
+        String result = testRule.client()
+                .target("/optional/some")
+                .request()
+                .get(String.class);
+
+        assertEquals("{}", result);
+    }
+
+    @Test(expected = javax.ws.rs.NotFoundException.class)
+    public void testOptionalResponseEmpty() {
+        testRule.client()
+                .target("/optional/empty")
+                .request()
+                .get(ClientResponseContext.class);
+    }
+
+}

--- a/dropwizard-java8-testing/src/test/java/io/dropwizard/java8/testing/junit/TestResource.java
+++ b/dropwizard-java8-testing/src/test/java/io/dropwizard/java8/testing/junit/TestResource.java
@@ -1,0 +1,47 @@
+package io.dropwizard.java8.testing.junit;
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.Optional;
+
+@Path("/optional")
+public class TestResource {
+
+    interface Check {
+        public void check(Optional<String> paramOne, Optional<Long> paramTwo);
+    }
+
+    private final Check check;
+
+    public TestResource(Check check) {
+        this.check = check;
+    }
+
+    @GET
+    @Path("/params")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String responseOk(@QueryParam("p1") Optional<String> paramOne,
+                             @QueryParam("p2") Optional<Long> paramTwo) {
+        check.check(paramOne, paramTwo);
+        return "{}";
+    }
+
+    @GET()
+    @Path("/some")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Optional<String> optional_some() {
+        return Optional.of("{}");
+    }
+
+    @GET()
+
+    @Path("/empty")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Optional<String> optional_empty() {
+        return Optional.empty();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>dropwizard-java8</module>
         <module>dropwizard-java8-auth</module>
         <module>dropwizard-java8-jdbi</module>
+        <module>dropwizard-java8-testing</module>
     </modules>
 
     <licenses>


### PR DESCRIPTION
The README helpfully suggests that everyone using a ```ResourceTestRule``` includes the 2 lines:

```java
    .addProvider(OptionalMessageBodyWriter.class)
    .addProvider(OptionalParamFeature.class)
```

This module adds a helper class to avoid that, and sets us up for other such testing helpers for Java 8