### PR TITLE
Update to 0.8.1 (with example)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ out/
 .settings/
 .classpath
 .project
+
+# Maven
+dependency-reduced-pom.xml

--- a/dropwizard-java8-auth/pom.xml
+++ b/dropwizard-java8-auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.modules</groupId>
         <artifactId>dropwizard-java8-parent</artifactId>
-        <version>0.8.0-3-SNAPSHOT</version>
+        <version>0.8.1-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>dropwizard-java8-auth</artifactId>

--- a/dropwizard-java8-example/pom.xml
+++ b/dropwizard-java8-example/pom.xml
@@ -8,15 +8,25 @@
 
     <groupId>io.dropwizard.modules.dropwizard</groupId>
     <artifactId>dropwizard-java8-example</artifactId>
-    <version>0.7.1</version>
+    <version>0.8.1-1-SNAPSHOT</version>
     <name>Dropwizard Example Application</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>0.7.1</dropwizard.version>
-        <dropwizard.java8.version>0.7.0-1</dropwizard.java8.version>
+        <dropwizard.version>0.8.1</dropwizard.version>
+        <dropwizard.java8.version>${project.version}</dropwizard.java8.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/dropwizard-java8-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
+++ b/dropwizard-java8-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
@@ -4,6 +4,7 @@ import com.example.helloworld.auth.ExampleAuthenticator;
 import com.example.helloworld.cli.RenderCommand;
 import com.example.helloworld.core.Person;
 import com.example.helloworld.core.Template;
+import com.example.helloworld.core.User;
 import com.example.helloworld.db.PersonDAO;
 import com.example.helloworld.health.TemplateHealthCheck;
 import com.example.helloworld.resources.HelloWorldResource;
@@ -12,7 +13,7 @@ import com.example.helloworld.resources.PersonResource;
 import com.example.helloworld.resources.ProtectedResource;
 import com.example.helloworld.resources.ViewResource;
 import io.dropwizard.java8.Java8Bundle;
-import io.dropwizard.java8.auth.basic.BasicAuthProvider;
+import io.dropwizard.java8.auth.basic.BasicAuthFactory;
 import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.db.DataSourceFactory;
@@ -52,7 +53,7 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
             }
         });
         bootstrap.addBundle(hibernateBundle);
-        bootstrap.addBundle(new ViewBundle());
+        bootstrap.addBundle(new ViewBundle<>());
     }
 
     @Override
@@ -62,7 +63,7 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
 
         environment.healthChecks().register("template", new TemplateHealthCheck(template));
 
-        environment.jersey().register(new BasicAuthProvider<>(new ExampleAuthenticator(), "SUPER SECRET STUFF"));
+        environment.jersey().register(new BasicAuthFactory<>(new ExampleAuthenticator(), "SUPER SECRET STUFF", User.class));
         environment.jersey().register(new HelloWorldResource(template));
         environment.jersey().register(new ViewResource());
         environment.jersey().register(new ProtectedResource());

--- a/dropwizard-java8-example/src/main/java/com/example/helloworld/resources/PersonResource.java
+++ b/dropwizard-java8-example/src/main/java/com/example/helloworld/resources/PersonResource.java
@@ -3,11 +3,11 @@ package com.example.helloworld.resources;
 import com.example.helloworld.core.Person;
 import com.example.helloworld.db.PersonDAO;
 import com.example.helloworld.views.PersonView;
-import com.sun.jersey.api.NotFoundException;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.dropwizard.jersey.params.LongParam;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;

--- a/dropwizard-java8-jdbi/pom.xml
+++ b/dropwizard-java8-jdbi/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.dropwizard.modules</groupId>
         <artifactId>dropwizard-java8-parent</artifactId>
-        <version>0.8.0-3-SNAPSHOT</version>
+        <version>0.8.1-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>dropwizard-java8-jdbi</artifactId>

--- a/dropwizard-java8/pom.xml
+++ b/dropwizard-java8/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.dropwizard.modules</groupId>
         <artifactId>dropwizard-java8-parent</artifactId>
-        <version>0.8.0-3-SNAPSHOT</version>
+        <version>0.8.1-1-SNAPSHOT</version>
     </parent>
 
     <artifactId>dropwizard-java8</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>io.dropwizard.modules</groupId>
     <artifactId>dropwizard-java8-parent</artifactId>
-    <version>0.8.0-3-SNAPSHOT</version>
+    <version>0.8.1-1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Dropwizard Java 8 Bundle</name>
@@ -25,6 +25,7 @@
         <module>dropwizard-java8</module>
         <module>dropwizard-java8-auth</module>
         <module>dropwizard-java8-jdbi</module>
+        <module>dropwizard-java8-example</module>
     </modules>
 
     <licenses>
@@ -70,8 +71,9 @@
         <autoVersionSubmodules>true</autoVersionSubmodules>
         <quiet>true</quiet>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>0.8.0</dropwizard.version>
-        <jersey.version>2.16</jersey.version>
+        <dropwizard.version>0.8.1</dropwizard.version>
+        <assertj.version>2.0.0</assertj.version>
+        <jersey.version>2.17</jersey.version>
         <jackson.version>2.5.1</jackson.version>
     </properties>
 
@@ -85,7 +87,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>1.7.1</version>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This change updates the java8 module for the 0.8.1 patch release, and synchronizes some dependencies with that release.

It also updates the example project to dropwizard 8; it hadn't been updated from dropwizard 7.
