### PR TITLE
Brings core and jdbi up-to-date with DW 0.9.0-rc4

### DIFF
--- a/dropwizard-java8-auth/pom.xml
+++ b/dropwizard-java8-auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.modules</groupId>
         <artifactId>dropwizard-java8-parent</artifactId>
-        <version>0.8.0-3-SNAPSHOT</version>
+        <version>0.9.0-rc4</version>
     </parent>
 
     <artifactId>dropwizard-java8-auth</artifactId>

--- a/dropwizard-java8-jdbi/pom.xml
+++ b/dropwizard-java8-jdbi/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.dropwizard.modules</groupId>
         <artifactId>dropwizard-java8-parent</artifactId>
-        <version>0.8.0-3-SNAPSHOT</version>
+        <version>0.9.0-rc4</version>
     </parent>
 
     <artifactId>dropwizard-java8-jdbi</artifactId>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/DBIFactory.java
+++ b/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/DBIFactory.java
@@ -12,6 +12,8 @@ import io.dropwizard.java8.jdbi.args.OptionalArgumentFactory;
 import io.dropwizard.setup.Environment;
 import org.skife.jdbi.v2.DBI;
 
+import java.util.TimeZone;
+
 public class DBIFactory extends io.dropwizard.jdbi.DBIFactory {
     @Override
     public DBI build(Environment environment, PooledDataSourceFactory configuration, ManagedDataSource dataSource, String name) {
@@ -19,12 +21,24 @@ public class DBIFactory extends io.dropwizard.jdbi.DBIFactory {
 
         dbi.registerArgumentFactory(new OptionalArgumentFactory(configuration.getDriverClass()));
         dbi.registerContainerFactory(new OptionalContainerFactory());
+
         dbi.registerArgumentFactory(new LocalDateArgumentFactory());
         dbi.registerArgumentFactory(new LocalDateTimeArgumentFactory());
-        dbi.registerArgumentFactory(new InstantArgumentFactory());
-        dbi.registerMapper(new InstantMapper());
         dbi.registerMapper(new LocalDateMapper());
         dbi.registerMapper(new LocalDateTimeMapper());
+
+        final com.google.common.base.Optional<TimeZone> gtz = this.databaseTimeZone();
+
+        final java.util.Optional<TimeZone> tz;
+        if (gtz.isPresent()) {
+            tz = java.util.Optional.of(gtz.get());
+        }
+        else {
+            tz = java.util.Optional.empty();
+        }
+
+        dbi.registerArgumentFactory(new InstantArgumentFactory(tz));
+        dbi.registerMapper(new InstantMapper(tz));
 
         return dbi;
     }

--- a/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/DBIFactory.java
+++ b/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/DBIFactory.java
@@ -1,5 +1,7 @@
 package io.dropwizard.java8.jdbi;
 
+import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.java8.jdbi.args.InstantArgumentFactory;
 import io.dropwizard.java8.jdbi.args.InstantMapper;
 import io.dropwizard.java8.jdbi.args.LocalDateArgumentFactory;
@@ -7,14 +9,12 @@ import io.dropwizard.java8.jdbi.args.LocalDateMapper;
 import io.dropwizard.java8.jdbi.args.LocalDateTimeArgumentFactory;
 import io.dropwizard.java8.jdbi.args.LocalDateTimeMapper;
 import io.dropwizard.java8.jdbi.args.OptionalArgumentFactory;
-import io.dropwizard.db.DataSourceFactory;
-import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.setup.Environment;
 import org.skife.jdbi.v2.DBI;
 
 public class DBIFactory extends io.dropwizard.jdbi.DBIFactory {
     @Override
-    public DBI build(Environment environment, DataSourceFactory configuration, ManagedDataSource dataSource, String name) {
+    public DBI build(Environment environment, PooledDataSourceFactory configuration, ManagedDataSource dataSource, String name) {
         final DBI dbi = super.build(environment, configuration, dataSource, name);
 
         dbi.registerArgumentFactory(new OptionalArgumentFactory(configuration.getDriverClass()));

--- a/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/InstantArgument.java
+++ b/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/InstantArgument.java
@@ -8,22 +8,34 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
+import java.util.Calendar;
+import java.util.Optional;
 
 /**
  * An {@link Argument} for {@link Instant} objects.
  */
 public class InstantArgument implements Argument {
 
-    private Instant instant;
+    private final Instant instant;
+    private final Optional<Calendar> calendar;
 
-    protected InstantArgument(Instant instant) {
+    protected InstantArgument(final Instant instant, final Optional<Calendar> calendar) {
         this.instant = instant;
+        this.calendar = calendar;
     }
 
     @Override
     public void apply(int position, PreparedStatement statement, StatementContext ctx) throws SQLException {
         if (instant != null) {
-            statement.setTimestamp(position, Timestamp.from(instant));
+            if (calendar.isPresent()) {
+                // We need to make a clone, because Calendar is not thread-safe
+                // and some JDBC drivers mutate it during time calculations
+                final Calendar calendarClone = (Calendar) calendar.get().clone();
+                statement.setTimestamp(position, Timestamp.from(instant), calendarClone);
+            }
+            else {
+                statement.setTimestamp(position, Timestamp.from(instant));
+            }
         } else {
             statement.setNull(position, Types.TIMESTAMP);
         }

--- a/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/InstantArgumentFactory.java
+++ b/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/InstantArgumentFactory.java
@@ -5,11 +5,32 @@ import org.skife.jdbi.v2.tweak.Argument;
 import org.skife.jdbi.v2.tweak.ArgumentFactory;
 
 import java.time.Instant;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
 
 /**
  * An {@link ArgumentFactory} for {@link Instant} arguments.
  */
 public class InstantArgumentFactory implements ArgumentFactory<Instant> {
+
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * If a field is not represented in a database as
+     * {@code TIMESTAMP WITH TIME ZONE}, we need to set its time zone
+     * explicitly. Otherwise it will not be correctly represented in
+     * a time zone different from the time zone of the database.
+     */
+    private final Optional<Calendar> calendar;
+
+    public InstantArgumentFactory() {
+        this(Optional.empty());
+    }
+
+    public InstantArgumentFactory(final Optional<TimeZone> tz) {
+        this.calendar = tz.map(GregorianCalendar::new);
+    }
 
     @Override
     public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx) {
@@ -18,6 +39,6 @@ public class InstantArgumentFactory implements ArgumentFactory<Instant> {
 
     @Override
     public Argument build(Class<?> expectedType, Instant value, StatementContext ctx) {
-        return new InstantArgument(value);
+        return new InstantArgument(value, calendar);
     }
 }

--- a/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/InstantMapper.java
+++ b/dropwizard-java8-jdbi/src/main/java/io/dropwizard/java8/jdbi/args/InstantMapper.java
@@ -6,15 +6,39 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
 
 /**
  * A {@link TypedMapper} to map {@link Instant} objects.
  */
 public class InstantMapper extends TypedMapper<Instant> {
 
+    /**
+     * <p>{@link Calendar} for representing a database time zone.<p>
+     * If a field is not represented in a database as
+     * {@code TIMESTAMP WITH TIME ZONE}, we need to set its time zone
+     * explicitly. Otherwise it will not be correctly represented in
+     * a time zone different from the time zone of the database.
+     */
+    private final Optional<Calendar> calendar;
+
+    public InstantMapper() {
+        this(Optional.empty());
+    }
+
+    public InstantMapper(final Optional<TimeZone> tz) {
+        this.calendar = tz.map(GregorianCalendar::new);
+    }
+
     @Override
     protected Instant extractByName(ResultSet r, String name) throws SQLException {
-        Timestamp timestamp = r.getTimestamp(name);
+        final Timestamp timestamp =
+                calendar.isPresent()
+                        ? r.getTimestamp(name, cloneCalendar())
+                        : r.getTimestamp(name);
         if (timestamp == null) {
             return null;
         }
@@ -23,10 +47,18 @@ public class InstantMapper extends TypedMapper<Instant> {
 
     @Override
     protected Instant extractByIndex(ResultSet r, int index) throws SQLException {
-        Timestamp timestamp = r.getTimestamp(index);
+        final Timestamp timestamp =
+                calendar.isPresent()
+                        ? r.getTimestamp(index, cloneCalendar())
+                        : r.getTimestamp(index);
         if (timestamp == null) {
             return null;
         }
         return timestamp.toInstant();
     }
+
+    private Calendar cloneCalendar() {
+        return (Calendar) calendar.get().clone();
+    }
+
 }

--- a/dropwizard-java8-jdbi/src/test/java/io/dropwizard/java8/jdbi/args/InstantArgumentTest.java
+++ b/dropwizard-java8-jdbi/src/test/java/io/dropwizard/java8/jdbi/args/InstantArgumentTest.java
@@ -9,6 +9,10 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.TimeZone;
 
 public class InstantArgumentTest {
 
@@ -16,18 +20,33 @@ public class InstantArgumentTest {
     private final StatementContext context = Mockito.mock(StatementContext.class);
 
     @Test
-    public void apply() throws Exception {
+    public void applyNoCalendar() throws Exception {
         ZonedDateTime zonedDateTime = ZonedDateTime.parse("2012-12-21T00:00:00.000Z");
         ZonedDateTime expected = zonedDateTime.withZoneSameInstant(ZoneId.systemDefault());
 
-        new InstantArgument(zonedDateTime.toInstant()).apply(1, statement, context);
+        new InstantArgument(zonedDateTime.toInstant(), Optional.empty()).apply(1, statement, context);
 
         Mockito.verify(statement).setTimestamp(1, Timestamp.from(expected.toInstant()));
     }
 
     @Test
-    public void apply_ValueIsNull() throws Exception {
-        new InstantArgument(null).apply(1, statement, context);
+    public void applyCalendar() throws Exception {
+        final ZoneId systemDefault = ZoneId.systemDefault();
+
+        // this test only asserts that a calendar was passed in. Not that the JDBC driver
+        // will do the right thing and adjust the time.
+        final ZonedDateTime zonedDateTime = ZonedDateTime.parse("2012-12-21T00:00:00.000Z");
+        final ZonedDateTime expected = zonedDateTime.withZoneSameInstant(systemDefault);
+        final Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone(systemDefault));
+
+        new InstantArgument(zonedDateTime.toInstant(), Optional.of(calendar)).apply(1, statement, context);
+
+        Mockito.verify(statement).setTimestamp(1, Timestamp.from(expected.toInstant()), calendar);
+    }
+
+    @Test
+    public void applyNoCalendar_ValueIsNull() throws Exception {
+        new InstantArgument(null, Optional.empty()).apply(1, statement, context);
 
         Mockito.verify(statement).setNull(1, Types.TIMESTAMP);
     }

--- a/dropwizard-java8/pom.xml
+++ b/dropwizard-java8/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.dropwizard.modules</groupId>
         <artifactId>dropwizard-java8-parent</artifactId>
-        <version>0.8.0-3-SNAPSHOT</version>
+        <version>0.9.0-rc4</version>
     </parent>
 
     <artifactId>dropwizard-java8</artifactId>

--- a/dropwizard-java8/src/main/java/io/dropwizard/java8/Java8Bundle.java
+++ b/dropwizard-java8/src/main/java/io/dropwizard/java8/Java8Bundle.java
@@ -1,30 +1,27 @@
 package io.dropwizard.java8;
 
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JSR310Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.dropwizard.Bundle;
 import io.dropwizard.java8.jersey.OptionalMessageBodyWriter;
 import io.dropwizard.java8.jersey.OptionalParamFeature;
 import io.dropwizard.java8.validation.valuehandling.OptionalValidatedValueUnwrapper;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import org.hibernate.validator.HibernateValidator;
 
-import javax.validation.Validation;
 import javax.validation.ValidatorFactory;
 
 public class Java8Bundle implements Bundle {
+
     @Override
     public void initialize(final Bootstrap<?> bootstrap) {
-        bootstrap.getObjectMapper().registerModules(new Jdk8Module());
-        bootstrap.getObjectMapper().registerModules(new JSR310Module());
+        bootstrap.getObjectMapper().registerModules(new Jdk8Module(), new JavaTimeModule());
 
-        final ValidatorFactory validatorFactory = Validation
-                .byProvider(HibernateValidator.class)
-                .configure()
-                .addValidatedValueHandler(new io.dropwizard.validation.valuehandling.OptionalValidatedValueUnwrapper())
-                .addValidatedValueHandler(new OptionalValidatedValueUnwrapper())
-                .buildValidatorFactory();
+        final ValidatorFactory validatorFactory =
+                Validators.newConfiguration()
+                    .addValidatedValueHandler(new OptionalValidatedValueUnwrapper())
+                    .buildValidatorFactory();
         bootstrap.setValidatorFactory(validatorFactory);
     }
 
@@ -33,4 +30,5 @@ public class Java8Bundle implements Bundle {
         environment.jersey().register(OptionalMessageBodyWriter.class);
         environment.jersey().register(OptionalParamFeature.class);
     }
+
 }

--- a/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalCookieParamResourceTest.java
+++ b/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalCookieParamResourceTest.java
@@ -1,10 +1,9 @@
 package io.dropwizard.java8.jersey;
 
 import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.java8.validation.valuehandling.OptionalValidatedValueUnwrapper;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.params.UUIDParam;
-import io.dropwizard.logging.LoggingFactory;
+import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
 
@@ -19,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalCookieParamResourceTest extends JerseyTest {
     static {
-        LoggingFactory.bootstrap();
+        BootstrapLogging.bootstrap();
     }
 
     @Override

--- a/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalFormParamResourceTest.java
+++ b/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalFormParamResourceTest.java
@@ -1,10 +1,9 @@
 package io.dropwizard.java8.jersey;
 
 import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.java8.validation.valuehandling.OptionalValidatedValueUnwrapper;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.params.UUIDParam;
-import io.dropwizard.logging.LoggingFactory;
+import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
@@ -23,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalFormParamResourceTest extends JerseyTest {
     static {
-        LoggingFactory.bootstrap();
+        BootstrapLogging.bootstrap();
     }
 
     @Override

--- a/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalHeaderParamResourceTest.java
+++ b/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalHeaderParamResourceTest.java
@@ -1,10 +1,9 @@
 package io.dropwizard.java8.jersey;
 
 import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.java8.validation.valuehandling.OptionalValidatedValueUnwrapper;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.params.UUIDParam;
-import io.dropwizard.logging.LoggingFactory;
+import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
 
@@ -13,14 +12,13 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
-
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalHeaderParamResourceTest extends JerseyTest {
     static {
-        LoggingFactory.bootstrap();
+        BootstrapLogging.bootstrap();
     }
 
     @Override

--- a/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalMessageBodyWriterTest.java
+++ b/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalMessageBodyWriterTest.java
@@ -2,7 +2,7 @@ package io.dropwizard.java8.jersey;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.DropwizardResourceConfig;
-import io.dropwizard.logging.LoggingFactory;
+import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
 
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class OptionalMessageBodyWriterTest extends JerseyTest {
     static {
-        LoggingFactory.bootstrap();
+        BootstrapLogging.bootstrap();
     }
 
     @Override

--- a/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalQueryParamResourceTest.java
+++ b/dropwizard-java8/src/test/java/io/dropwizard/java8/jersey/OptionalQueryParamResourceTest.java
@@ -1,10 +1,9 @@
 package io.dropwizard.java8.jersey;
 
 import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.java8.validation.valuehandling.OptionalValidatedValueUnwrapper;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.params.UUIDParam;
-import io.dropwizard.logging.LoggingFactory;
+import io.dropwizard.logging.BootstrapLogging;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
 
@@ -13,14 +12,13 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Application;
-
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OptionalQueryParamResourceTest extends JerseyTest {
     static {
-        LoggingFactory.bootstrap();
+        BootstrapLogging.bootstrap();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>io.dropwizard.modules</groupId>
     <artifactId>dropwizard-java8-parent</artifactId>
-    <version>0.8.0-3-SNAPSHOT</version>
+    <version>0.9.0-rc4</version>
     <packaging>pom</packaging>
 
     <name>Dropwizard Java 8 Bundle</name>
@@ -23,7 +23,7 @@
 
     <modules>
         <module>dropwizard-java8</module>
-        <module>dropwizard-java8-auth</module>
+        <!--<module>dropwizard-java8-auth</module>-->
         <module>dropwizard-java8-jdbi</module>
     </modules>
 
@@ -70,9 +70,9 @@
         <autoVersionSubmodules>true</autoVersionSubmodules>
         <quiet>true</quiet>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>0.8.0</dropwizard.version>
-        <jersey.version>2.16</jersey.version>
-        <jackson.version>2.5.1</jackson.version>
+        <dropwizard.version>0.9.0-rc4</dropwizard.version>
+        <jersey.version>2.21</jersey.version>
+        <jackson.version>2.6.1</jackson.version>
     </properties>
 
     <dependencies>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>1.7.1</version>
+            <version>2.1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
So this PR brings core and jdbi up-to-date with DW 0.9.0-rc4. It does not do anything to the auth submodule because I don't use the auth submodule. I'm working on it, but I wanted to get this out for some eyeballs to look at it.

For validation, uses the new Validators class to get a configuration to add to. This ensures that all the standard validation value handlers are included.

For jackson, uses JavaTimeModule instead of JSR310Module, which was deprecated.

For jDBI, brings it up-to-date with signature changes in 0.9.x and also adapts the TimeZone code from the Joda-Time argument and mappers for the Instant argument and mappers. LocalDate and LocalDateTime are left alone.